### PR TITLE
Make the composer type drupal-module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "drupal/pacifica_content",
     "description": "Pacifica content types for metadata.",
     "license": "LGPL-3.0",
+    "type": "drupal-module",
     "authors": [
         {
             "name": "David Brown",


### PR DESCRIPTION
### Description

This changes the composer package type to drupal-module. This
should make composer install the module in the correct place.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
